### PR TITLE
Use copy() & unlink() instead of rename()

### DIFF
--- a/src/GlideConversion.php
+++ b/src/GlideConversion.php
@@ -98,7 +98,8 @@ final class GlideConversion
 
         $conversionResultDirectory = pathinfo($this->conversionResult, PATHINFO_DIRNAME);
 
-        rename($this->conversionResult, $outputFile);
+        copy($this->conversionResult, $outputFile);
+        unlink($this->conversionResult);
 
         if ($this->directoryIsEmpty($conversionResultDirectory)) {
             rmdir($conversionResultDirectory);


### PR DESCRIPTION
Using `copy()` & `unlink()` instead of `rename()` as the latter will produce warnings and `GlideConversion` will throw an `ErrorException` if it is used across different volumes/disks.

See Changelog notes in http://php.net/manual/en/function.rename.php